### PR TITLE
Update `recipes/releases.yaml` to reflect new parent issue title and add custom labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To run the CLI, run `./releaseman.sh <args>`. To see command help run `./release
 
 #### `./releaseman.sh release [OPTIONS]`
 
-Creates issues for a numbered release. Parent issues represent the release, and child issues represent each step in the
+Creates issues for a numbered release. Parent issues represent the "[U{upgrade_number}] Interop Contracts Release Readiness Tracker", and child issues represent each step in the
 release process. Used by the release management [board].
 
 [board]: https://github.com/orgs/ethereum-optimism/projects/117/views/12

--- a/recipes/releases.yaml
+++ b/recipes/releases.yaml
@@ -2,6 +2,8 @@ global_prefix: "[U{upgrade_number}] "
 
 global_labels:
   - "M-tracking-{upgrade_number}"
+  - "custom-label-1"
+  - "custom-label-2"
 
 parent_issue:
   title: "[U{upgrade_number}] Interop Contracts Release Readiness Tracker"
@@ -46,4 +48,3 @@ issues:
   - title: "Execute mainnet superchain-ops task"
   - title: "Roll mainnet reminder comms"
   - title: "Activate HF on mainnet"
-  

--- a/recipes/releases.yaml
+++ b/recipes/releases.yaml
@@ -4,7 +4,7 @@ global_labels:
   - "M-tracking-{upgrade_number}"
 
 parent_issue:
-  title: "Release Readiness Tracker"
+  title: "[U{upgrade_number}] Interop Contracts Release Readiness Tracker"
 
 issues:
   - title: "Code complete"


### PR DESCRIPTION
* Update the `title` field of the `parent_issue` to "[U{upgrade_number}] Interop Contracts Release Readiness Tracker"
* Add custom labels to the `global_labels` field

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
