### PR TITLE
Remove auto-creation of devnet issues

### DIFF
--- a/recipes/releases.yaml
+++ b/recipes/releases.yaml
@@ -24,8 +24,6 @@ issues:
   - title: "Add audits to monorepo"
   - title: "Automate acceptance tests"
     body: "Automate any acceptance tests previously identified as being required to validate the release."
-  - title: "Deploy to Alphanet"
-  - title: "Deploy to Betanet"
   - title: "Draft governance post"
   - title: "Update Standard Rollup Charter"
   - title: "Roll initial hardfork notification comms"


### PR DESCRIPTION
The auto-creation of devnet issues is creating some confusion when tracking releases, as we often create devnet issues manually using the nice issue template we have for these requests.

Aligned with PMO [here](https://oplabs-pbc.slack.com/archives/C0885T0HRCG/p1745511860958939?thread_ts=1745499716.185479&cid=C0885T0HRCG) to remove the devnet issue creation automation and rely on the issue template flow instead.